### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ jobs:
     with:
       go-version-file: go.mod
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,9 @@ jobs:
       - run: exit 1
   sub:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write

--- a/.github/workflows/workflow_call_integration_test.yaml
+++ b/.github/workflows/workflow_call_integration_test.yaml
@@ -1,10 +1,16 @@
 ---
 name: integration test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   integration-test:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write
+      contents: read
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -13,6 +19,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
           aqua_version: v2.59.1

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,17 +1,28 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   integration-test:
     uses: ./.github/workflows/workflow_call_integration_test.yaml
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      id-token: write
+      contents: read
 
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard (Go variant) into the CI workflows to harden module downloads against supply-chain attacks.

## Changes

- `.github/workflows/release.yaml`: add a `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to the `go-release-workflow` call (ref already pinned at v8.1.0).
- `.github/workflows/workflow_call_test.yaml`: declare the required `TAKUMI_GUARD_BOT_ID` secret on `workflow_call`; bump `go-test-full-workflow` from `v5.0.2` to `v6.0.0` and add the `secrets:` block plus `id-token: write` to the `test` job; pass the secret to the local `integration-test` call and add `id-token: write` / `contents: read` to that job.
- `.github/workflows/workflow_call_integration_test.yaml`: declare the required `TAKUMI_GUARD_BOT_ID` secret on `workflow_call`; insert the `flatt-security/setup-takumi-guard-golang@v1` step after `actions/setup-go` and before `aquaproj/aqua-installer` (which precedes `go install`); change the job `permissions` from `{}` to `id-token: write` + `contents: read`.
- `.github/workflows/test.yaml`: pass `TAKUMI_GUARD_BOT_ID` to the local `workflow_call_test.yaml` call and add `id-token: write` to the `sub` job so the secret and token reach the test chain from the `pull_request` entrypoint.

## Note

The `go-test-full-workflow` reusable workflow was bumped across a major version (v5.0.2 -> v6.0.0). Please review CI for breaking changes.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)